### PR TITLE
meson: move to c_std=gnu11

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('systemd', 'c',
         version : '250',
         license : 'LGPLv2+',
         default_options: [
-                'c_std=gnu99',
+                'c_std=gnu11',
                 'prefix=/usr',
                 'sysconfdir=/etc',
                 'localstatedir=/var',


### PR DESCRIPTION
Recently, the kernel communitiy started to discuss to move C11 (gnu11) [1],
and it seems to come near future.
Let's also move to c_std=gnu11. Unlike the kernel, we already uses
gnu99, hence hopefully we can move to C11 without changing anything.

[1] https://lore.kernel.org/lkml/CAHk-=wiyCH7xeHcmiFJ-YgXUy2Jaj7pnkdKpcovt8fYbVFW3TA@mail.gmail.com/